### PR TITLE
Force keeping independent state of coordinates and custom mine setup

### DIFF
--- a/api/src/test/scala/io/scalac/minesweeper/api/BoardFactorySpec.scala
+++ b/api/src/test/scala/io/scalac/minesweeper/api/BoardFactorySpec.scala
@@ -8,10 +8,15 @@ abstract class BoardFactorySpec(create: () => BoardFactory) extends FunSuite {
     assertEquals(board.allCoordinates.size, 5)
   }
 
-  test("Should set mines correctly") {
+  test("Should set mines on even number of neighbors") {
     val board = create().create(5, _.neighbors.size % 2 == 0)
     board.allCoordinates.foreach(c =>
       assertEquals(c.neighbors.size % 2 == 0, board.hasMine(c))
     )
+  }
+
+  test("Should set all mines") {
+    val board = create().create(5, _ => true)
+    board.allCoordinates.foreach(c => assert(board.hasMine(c)))
   }
 }

--- a/api/src/test/scala/io/scalac/minesweeper/api/BoardSpec.scala
+++ b/api/src/test/scala/io/scalac/minesweeper/api/BoardSpec.scala
@@ -19,12 +19,34 @@ abstract class BoardSpec(factory: BoardFactory) extends FunSuite {
       .foreach(assertEquals(_, PlayerState.Flagged))
   }
 
+  test("Flagging one cell should not affect other cells") {
+    val board = createBoard()
+
+    board.allCoordinates
+      .map(coordinate => (coordinate, board.flag(coordinate)))
+      .foreach { case (coordinate, updatedBoard) =>
+        updatedBoard.allCoordinates
+          .filterNot(_ == coordinate)
+          .foreach { c =>
+            assertEquals(updatedBoard.playerState(c), board.playerState(c))
+          }
+      }
+  }
+
   test("Uncovering any empty cell should set coordinate as uncovered") {
     val board = createBoard()
 
     coordinatesWithoutMine(board)
       .map(coordinate => board.uncover(coordinate).playerState(coordinate))
       .foreach(assertEquals(_, PlayerState.Uncovered))
+  }
+
+  test("Uncovering some empty cell should keep state as Playing") {
+    val board = createBoard()
+
+    coordinatesWithoutMine(board)
+      .map(coordinate => board.uncover(coordinate).state)
+      .foreach(assertEquals(_, BoardState.Playing))
   }
 
   test("Board state should start as Playing") {

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
@@ -2,9 +2,9 @@ package io.scalac.minesweeper.squared
 
 import io.scalac.minesweeper.api.*
 
-class SquaredBoard extends Board {
+class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board {
   override def uncover(coordinate: Coordinate): Board =
-    new SquaredBoard {
+    new SquaredBoard(size, _hasMine) {
       override def playerState(_coordinate: Coordinate): PlayerState =
         if (SquaredBoard.this.playerState(_coordinate) == PlayerState.Flagged)
           PlayerState.Flagged
@@ -17,21 +17,27 @@ class SquaredBoard extends Board {
             SquaredBoard.this.state
           else
             BoardState.Lost
-        else
-          BoardState.Won
+        else if (won()) BoardState.Won
+        else BoardState.Playing
     }
 
+  private def won(): Boolean =
+    allCoordinates
+      .filter(!hasMine(_))
+      .forall(playerState(_) == PlayerState.Uncovered)
+
   override def flag(coordinate: Coordinate): Board =
-    new SquaredBoard {
+    new SquaredBoard(size, _hasMine) {
       override def playerState(_coordinate: Coordinate): PlayerState =
-        PlayerState.Flagged
+        if (_coordinate == coordinate) PlayerState.Flagged
+        else SquaredBoard.this.playerState(_coordinate)
     }
 
   override def allCoordinates: Seq[Coordinate] =
-    Seq.tabulate(5)(SquaredCoordinate(_, 0))
+    Seq.tabulate(size)(SquaredCoordinate(_, 0))
 
   override def hasMine(coordinate: Coordinate): Boolean =
-    coordinate.neighbors.size % 2 == 0
+    _hasMine(coordinate)
 
   override def playerState(coordinate: Coordinate): PlayerState =
     PlayerState.Covered

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoardFactory.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoardFactory.scala
@@ -4,5 +4,5 @@ import io.scalac.minesweeper.api.{BoardFactory, Coordinate}
 
 class SquaredBoardFactory extends BoardFactory {
   override def create(size: Int, hasMine: Coordinate => Boolean): SquaredBoard =
-    new SquaredBoard
+    new SquaredBoard(size, hasMine)
 }


### PR DESCRIPTION
With these new tests the implementation finally makes more sense.
It keeps the state of each independent coordinate, and the setting of which one has mine is not just stolen from the spec.
Why does it still not look truly as a "squared" implementation of the game?