### PR TITLE
Test squared implementation specifically

### DIFF
--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
@@ -3,20 +3,19 @@ package io.scalac.minesweeper.squared
 import io.scalac.minesweeper.api.*
 
 class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board {
+  previous =>
   override def uncover(coordinate: Coordinate): Board =
     new SquaredBoard(size, _hasMine) {
       override def playerState(_coordinate: Coordinate): PlayerState =
-        if (SquaredBoard.this.playerState(_coordinate) == PlayerState.Flagged)
+        if (previous.playerState(_coordinate) == PlayerState.Flagged)
           PlayerState.Flagged
         else
           PlayerState.Uncovered
 
       override def state: BoardState =
         if (hasMine(coordinate))
-          if (playerState(coordinate) == PlayerState.Flagged)
-            SquaredBoard.this.state
-          else
-            BoardState.Lost
+          if (playerState(coordinate) == PlayerState.Flagged) previous.state
+          else BoardState.Lost
         else if (won()) BoardState.Won
         else BoardState.Playing
     }
@@ -30,11 +29,13 @@ class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board {
     new SquaredBoard(size, _hasMine) {
       override def playerState(_coordinate: Coordinate): PlayerState =
         if (_coordinate == coordinate) PlayerState.Flagged
-        else SquaredBoard.this.playerState(_coordinate)
+        else previous.playerState(_coordinate)
     }
 
-  override def allCoordinates: Seq[Coordinate] =
-    Seq.tabulate(size)(SquaredCoordinate(_, 0))
+  override lazy val allCoordinates: Seq[SquaredCoordinate] = {
+    val sqrt = math.sqrt(size.toDouble).round.toInt
+    (0 until size).map(n => SquaredCoordinate(n / sqrt, n % sqrt, size))
+  }
 
   override def hasMine(coordinate: Coordinate): Boolean =
     _hasMine(coordinate)

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredCoordinate.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredCoordinate.scala
@@ -2,7 +2,36 @@ package io.scalac.minesweeper.squared
 
 import io.scalac.minesweeper.api.Coordinate
 
-final case class SquaredCoordinate(x: Int, y: Int) extends Coordinate {
-  override val neighbors: Seq[Coordinate] =
-    Seq.tabulate(x)(SquaredCoordinate(_, 0))
+final case class SquaredCoordinate(x: Int, y: Int, boardSize: Int)
+    extends Coordinate {
+
+  private val lastIndex = boardSize - 1
+
+  override lazy val neighbors: Seq[Coordinate] =
+    Seq(
+      Option.when(x > 0 && y > 0)(
+        SquaredCoordinate(x - 1, y - 1, boardSize)
+      ),
+      Option.when(x > 0)(
+        SquaredCoordinate(x - 1, y, boardSize)
+      ),
+      Option.when(x > 0 && y < lastIndex)(
+        SquaredCoordinate(x - 1, y + 1, boardSize)
+      ),
+      Option.when(y > 0)(
+        SquaredCoordinate(x, y - 1, boardSize)
+      ),
+      Option.when(y < lastIndex)(
+        SquaredCoordinate(x, y + 1, boardSize)
+      ),
+      Option.when(x < lastIndex && y > 0)(
+        SquaredCoordinate(x + 1, y - 1, boardSize)
+      ),
+      Option.when(x < lastIndex)(
+        SquaredCoordinate(x + 1, y, boardSize)
+      ),
+      Option.when(x < lastIndex && y < lastIndex)(
+        SquaredCoordinate(x + 1, y + 1, boardSize)
+      )
+    ).flatten
 }

--- a/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredBoardSpec.scala
+++ b/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredBoardSpec.scala
@@ -2,4 +2,15 @@ package io.scalac.minesweeper.squared
 
 import io.scalac.minesweeper.api.BoardSpec
 
-class SquaredBoardSpec extends BoardSpec(new SquaredBoardFactory)
+class SquaredBoardSpec extends BoardSpec(new SquaredBoardFactory) {
+  test("Should contain all coordinates") {
+    val board = new SquaredBoard(9, _ => false)
+    val coordinates = for {
+      x <- 0 until 3
+      y <- 0 until 3
+    } yield SquaredCoordinate(x, y, 9)
+
+    board.allCoordinates.foreach(c => assert(coordinates.contains(c)))
+    coordinates.foreach(c => assert(board.allCoordinates.contains(c)))
+  }
+}

--- a/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredCoordinateSpec.scala
+++ b/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredCoordinateSpec.scala
@@ -1,0 +1,34 @@
+package io.scalac.minesweeper.squared
+
+import munit.FunSuite
+
+class SquaredCoordinateSpec extends FunSuite {
+  private val boardSize = 8
+  private val lastIndex = boardSize - 1
+  private val extremes = Seq(0, lastIndex)
+  private val middle = 1 until lastIndex
+
+  test("Corners should have 3 neighbors") {
+    product(extremes, extremes)
+      .map(_.neighbors.size)
+      .foreach(assertEquals(_, 3))
+  }
+
+  test("Borders should have 5 neighbors") {
+    (product(middle, extremes) ++ product(extremes, middle))
+      .map(_.neighbors.size)
+      .foreach(assertEquals(_, 5))
+  }
+
+  test("Internal should have 8 neighbors") {
+    product(middle, middle)
+      .map(_.neighbors.size)
+      .foreach(assertEquals(_, 8))
+  }
+
+  private def product(xs: Seq[Int], ys: Seq[Int]): Seq[SquaredCoordinate] =
+    for {
+      x <- xs
+      y <- ys
+    } yield SquaredCoordinate(x, y, boardSize)
+}


### PR DESCRIPTION
The squared implementation doesn't have any actual requirement to be squared.
The abstract `api` tests can't check that because in fact they don't care about implementation details.
Tests have to be added in the `squared` module itself and by knowing the implementation details, more specific tests can be added, and the implementation now is forced to show more squared-like properties.