### PR TITLE
Add stryker4s for mutation testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
         run: nix develop -c sbt lint
       - name: Test
         run: nix develop -c sbt testCoverage
+      - name: Mutation test
+        run: nix develop -c sbt mutationTest

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ documentation to find more about how they work:
 - [Scapegoat](https://github.com/scapegoat-scala/sbt-scapegoat) - Static linter
 - [Scalafmt](https://scalameta.org/scalafmt/docs/installation.html#sbt) - Code formatter
 - [Scoverage](https://github.com/scoverage/sbt-scoverage) - Code coverage
+- [Stryker](https://stryker-mutator.io/docs/stryker4s/getting-started/) - Mutation testing
 
 There are some sbt command alias provided as well:
 - `checkFormat` - Check all Scala files to verify their formatting.
 - `lint` - Compile with strict flags enabled plus wartremover checks and run scapegoat.
 - `testCoverage` - Enable coverage, run test, generate a report, and verify that minimum code coverage
 is reached.
+- `mutationTest` - Introduce changes to the code, run tests, and verify that some test fails.
 - `verify` - Run all the above sequentially.

--- a/build.sbt
+++ b/build.sbt
@@ -32,4 +32,5 @@ lazy val squared =
 addCommandAlias("checkFormat", ";scalafmtSbtCheck ;scalafmtCheckAll")
 addCommandAlias("lint", ";compile ;scapegoat")
 addCommandAlias("testCoverage", ";coverage ;test ;coverageReport")
-addCommandAlias("verify", ";checkFormat ;lint ;testCoverage")
+addCommandAlias("mutationTest", ";project squared ;stryker")
+addCommandAlias("verify", ";checkFormat ;lint ;testCoverage; mutationTest")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,6 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.5")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.1")
+addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.14.3")
+
+dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.1.0"

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
@@ -7,10 +7,10 @@ class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board {
   override def uncover(coordinate: Coordinate): Board =
     new SquaredBoard(size, _hasMine) {
       override def playerState(_coordinate: Coordinate): PlayerState =
-        if (previous.playerState(_coordinate) == PlayerState.Flagged)
-          PlayerState.Flagged
-        else
+        if (_coordinate == coordinate && !previous.isFlagged(_coordinate))
           PlayerState.Uncovered
+        else
+          previous.playerState(_coordinate)
 
       override def state: BoardState =
         if (hasMine(coordinate))
@@ -18,12 +18,15 @@ class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board {
           else BoardState.Lost
         else if (won()) BoardState.Won
         else BoardState.Playing
+
+      private def won(): Boolean =
+        allCoordinates
+          .filterNot(hasMine)
+          .forall(playerState(_) == PlayerState.Uncovered)
     }
 
-  private def won(): Boolean =
-    allCoordinates
-      .filter(!hasMine(_))
-      .forall(playerState(_) == PlayerState.Uncovered)
+  private def isFlagged(coordinate: Coordinate): Boolean =
+    playerState(coordinate) == PlayerState.Flagged
 
   override def flag(coordinate: Coordinate): Board =
     new SquaredBoard(size, _hasMine) {

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -1,0 +1,7 @@
+stryker4s {
+  thresholds {
+    high = 100
+    low = 100
+    break = 99
+  }
+}


### PR DESCRIPTION
Adding mutation testing immediately uncovers some code that, even after changing it to its opposite (`filter` to `filterNot`), the tests would still pass.
Turns out this was actually a bug that our test suite didn't catch.