### PR TITLE
Implement CLI

### DIFF
--- a/api/src/main/scala/io/scalac/minesweeper/api/Board.scala
+++ b/api/src/main/scala/io/scalac/minesweeper/api/Board.scala
@@ -12,4 +12,8 @@ trait Board {
   def playerState(coordinate: Coordinate): PlayerState
 
   def state: BoardState
+
+  def show: String
+
+  def size: Int
 }

--- a/api/src/test/scala/io/scalac/minesweeper/api/BoardSpec.scala
+++ b/api/src/test/scala/io/scalac/minesweeper/api/BoardSpec.scala
@@ -24,6 +24,15 @@ abstract class BoardSpec(factory: BoardFactory) extends ScalaCheckSuite {
     }
   }
 
+  property("Flagging twice should remove flag") {
+    forAll(boardGen) { board =>
+      forAll(coordinateGen(board)) { coordinate =>
+        val flaggedBoard = board.flag(coordinate).flag(coordinate)
+        assertEquals(flaggedBoard.playerState(coordinate), PlayerState.Covered)
+      }
+    }
+  }
+
   property("Flagging one cell should not affect other cells") {
     forAll(boardGen) { board =>
       forAll(coordinateGen(board)) { coordinate =>

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ lazy val commonSettings = Seq(
   wartremoverErrors ++= Warts.unsafe.diff(Seq(Wart.Any)),
   coverageFailOnMinimum := true,
   coverageMinimumStmtTotal := 100,
-  coverageMinimumBranchTotal := 100
+  coverageMinimumBranchTotal := 100,
+  coverageExcludedPackages := "io.scalac.minesweeper.cli*"
 )
 
 lazy val api =
@@ -28,6 +29,25 @@ lazy val squared =
     .dependsOn(api % "test->test;compile->compile")
     .settings(
       name := "minesweeper-squared"
+    )
+
+lazy val cli =
+  project
+    .in(file("cli"))
+    .settings(commonSettings)
+    .dependsOn(api % "test->test;compile->compile")
+    .settings(
+      name := "minesweeper-cli",
+      libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.14"
+    )
+
+lazy val `cli-squared` =
+  project
+    .in(file("cli-squared"))
+    .settings(commonSettings)
+    .dependsOn(cli, squared)
+    .settings(
+      name := "minesweeper-cli-squared"
     )
 
 addCommandAlias("checkFormat", ";scalafmtSbtCheck ;scalafmtCheckAll")

--- a/cli-squared/src/main/scala/io/scalac/minesweeper/cli/squared/Main.scala
+++ b/cli-squared/src/main/scala/io/scalac/minesweeper/cli/squared/Main.scala
@@ -1,0 +1,7 @@
+package io.scalac.minesweeper.cli.squared
+
+import io.scalac.minesweeper.cli.MinesweeperCLI
+import io.scalac.minesweeper.squared.SquaredBoardFactory
+
+object Main
+    extends MinesweeperCLI(new SquaredBoardFactory, SquaredMovementParser)

--- a/cli-squared/src/main/scala/io/scalac/minesweeper/cli/squared/SquaredMovementParser.scala
+++ b/cli-squared/src/main/scala/io/scalac/minesweeper/cli/squared/SquaredMovementParser.scala
@@ -1,0 +1,7 @@
+package io.scalac.minesweeper.cli.squared
+
+import io.scalac.minesweeper.cli.MovementParser
+import io.scalac.minesweeper.squared.SquaredCoordinateParser
+
+object SquaredMovementParser
+    extends MovementParser(SquaredCoordinateParser.parse(_, _))

--- a/cli/src/main/scala/io/scalac/minesweeper/cli/CoordinateParser.scala
+++ b/cli/src/main/scala/io/scalac/minesweeper/cli/CoordinateParser.scala
@@ -1,0 +1,7 @@
+package io.scalac.minesweeper.cli
+
+import io.scalac.minesweeper.api.{Board, Coordinate}
+
+trait CoordinateParser {
+  def parse(input: String, board: Board): Option[Coordinate]
+}

--- a/cli/src/main/scala/io/scalac/minesweeper/cli/MinesweeperCLI.scala
+++ b/cli/src/main/scala/io/scalac/minesweeper/cli/MinesweeperCLI.scala
@@ -1,0 +1,61 @@
+package io.scalac.minesweeper.cli
+
+import cats.effect.*
+import cats.syntax.monad.*
+import io.scalac.minesweeper.api.*
+import io.scalac.minesweeper.cli.Movement.{Flag, Uncover}
+import scala.collection.mutable
+import scala.util.Random
+
+class MinesweeperCLI(boardFactory: BoardFactory, movementParser: MovementParser)
+    extends IOApp {
+  val readSize: IO[Int] =
+    for {
+      _ <- IO.print("Size: ")
+      input <- IO.readLine
+      size <-
+        input.toIntOption
+          .map(IO.pure)
+          .getOrElse(IO.println("Invalid size") >> readSize)
+    } yield size
+
+  val readDifficulty: IO[Double] =
+    for {
+      _ <- IO.print("Difficulty: ")
+      input <- IO.readLine
+      difficulty <- input.toDoubleOption
+        .map(IO.pure)
+        .getOrElse(IO.println("Invalid difficulty") >> readDifficulty)
+    } yield difficulty
+
+  def makeMove(board: Board, input: String): Either[String, Board] =
+    movementParser.parse(input, board) match {
+      case Right(Uncover(coordinate)) => Right(board.uncover(coordinate))
+      case Right(Flag(coordinate))    => Right(board.flag(coordinate))
+      case Left(error)                => Left(error)
+    }
+
+  def mainLoop(board: Board): IO[Board] =
+    for {
+      _ <- IO.println(board.show)
+      _ <- IO.print("Play: ")
+      input <- IO.readLine
+      newBoard <- makeMove(board, input).fold(IO.println(_).as(board), IO.pure)
+    } yield newBoard
+
+  val game: IO[Unit] = for {
+    size <- readSize
+    difficulty <- readDifficulty
+    mines = mutable.Map.empty[Coordinate, Boolean]
+    initialBoard = boardFactory.create(
+      size,
+      mines.getOrElseUpdate(_, Random.nextDouble() < difficulty)
+    )
+    finalBoard <-
+      initialBoard.iterateWhileM(mainLoop)(_.state == BoardState.Playing)
+    _ <- IO.println(s"You ${finalBoard.state.toString}!")
+  } yield ()
+
+  override def run(args: List[String]): IO[ExitCode] =
+    game.as(ExitCode.Success)
+}

--- a/cli/src/main/scala/io/scalac/minesweeper/cli/Movement.scala
+++ b/cli/src/main/scala/io/scalac/minesweeper/cli/Movement.scala
@@ -1,0 +1,12 @@
+package io.scalac.minesweeper.cli
+
+import io.scalac.minesweeper.api.Coordinate
+
+sealed trait Movement {
+  def coordinate: Coordinate
+}
+
+object Movement {
+  final case class Uncover(coordinate: Coordinate) extends Movement
+  final case class Flag(coordinate: Coordinate) extends Movement
+}

--- a/cli/src/main/scala/io/scalac/minesweeper/cli/MovementParser.scala
+++ b/cli/src/main/scala/io/scalac/minesweeper/cli/MovementParser.scala
@@ -1,0 +1,25 @@
+package io.scalac.minesweeper.cli
+
+import io.scalac.minesweeper.api.Board
+import io.scalac.minesweeper.cli.Movement.{Flag, Uncover}
+import scala.util.matching.Regex
+
+class MovementParser(coordinateParser: CoordinateParser) {
+  private val uncover = "u"
+  private val flag = "f"
+  val regex: Regex = """^([uf]) (.+)$""".r
+
+  def parse(input: String, board: Board): Either[String, Movement] =
+    input match {
+      case regex(movement, coordinateString) =>
+        val maybeCoordinate =
+          coordinateParser.parse(coordinateString, board)
+        (movement, maybeCoordinate) match {
+          case (`uncover`, Some(coordinate)) => Right(Uncover(coordinate))
+          case (`flag`, Some(coordinate))    => Right(Flag(coordinate))
+          case _                             => Left("Invalid coordinate")
+        }
+
+      case _ => Left("Invalid input")
+    }
+}

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredCoordinate.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredCoordinate.scala
@@ -4,34 +4,29 @@ import io.scalac.minesweeper.api.Coordinate
 
 final case class SquaredCoordinate(x: Int, y: Int, boardSize: Int)
     extends Coordinate {
-
-  private val lastIndex = boardSize - 1
-
-  override lazy val neighbors: Seq[Coordinate] =
+  override lazy val neighbors: Seq[Coordinate] = {
     Seq(
-      Option.when(x > 0 && y > 0)(
-        SquaredCoordinate(x - 1, y - 1, boardSize)
-      ),
-      Option.when(x > 0)(
-        SquaredCoordinate(x - 1, y, boardSize)
-      ),
-      Option.when(x > 0 && y < lastIndex)(
-        SquaredCoordinate(x - 1, y + 1, boardSize)
-      ),
-      Option.when(y > 0)(
-        SquaredCoordinate(x, y - 1, boardSize)
-      ),
-      Option.when(y < lastIndex)(
-        SquaredCoordinate(x, y + 1, boardSize)
-      ),
-      Option.when(x < lastIndex && y > 0)(
-        SquaredCoordinate(x + 1, y - 1, boardSize)
-      ),
-      Option.when(x < lastIndex)(
-        SquaredCoordinate(x + 1, y, boardSize)
-      ),
-      Option.when(x < lastIndex && y < lastIndex)(
-        SquaredCoordinate(x + 1, y + 1, boardSize)
-      )
+      SquaredCoordinate.validated(x - 1, y - 1, boardSize),
+      SquaredCoordinate.validated(x - 1, y, boardSize),
+      SquaredCoordinate.validated(x - 1, y + 1, boardSize),
+      SquaredCoordinate.validated(x, y - 1, boardSize),
+      SquaredCoordinate.validated(x, y + 1, boardSize),
+      SquaredCoordinate.validated(x + 1, y - 1, boardSize),
+      SquaredCoordinate.validated(x + 1, y, boardSize),
+      SquaredCoordinate.validated(x + 1, y + 1, boardSize)
     ).flatten
+  }
+}
+
+object SquaredCoordinate {
+  def validated(x: Int, y: Int, boardSize: Int): Option[SquaredCoordinate] = {
+    val max = maxIndex(boardSize)
+    if (x >= 0 && x <= max && y >= 0 && y <= max)
+      Some(new SquaredCoordinate(x, y, boardSize))
+    else
+      None
+  }
+
+  def maxIndex(boardSize: Int): Int =
+    math.sqrt(boardSize.toDouble).round.toInt - 1
 }

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredCoordinateParser.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredCoordinateParser.scala
@@ -1,0 +1,24 @@
+package io.scalac.minesweeper.squared
+
+import io.scalac.minesweeper.api.{Board, Coordinate}
+import scala.util.matching.Regex
+
+object SquaredCoordinateParser {
+  val regex: Regex = """(\d+) (\d+)""".r
+
+  def parse(input: String, board: Board): Option[Coordinate] =
+    input match {
+      case regex(x, y) =>
+        for {
+          validatedX <- x.toIntOption
+          validatedY <- y.toIntOption
+          coordinate <- SquaredCoordinate.validated(
+            validatedX,
+            validatedY,
+            board.size
+          )
+        } yield coordinate
+      case _ =>
+        None
+    }
+}

--- a/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredBoardSpec.scala
+++ b/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredBoardSpec.scala
@@ -1,6 +1,6 @@
 package io.scalac.minesweeper.squared
 
-import io.scalac.minesweeper.api.BoardSpec
+import io.scalac.minesweeper.api.{Board, BoardSpec, Coordinate}
 
 class SquaredBoardSpec extends BoardSpec(new SquaredBoardFactory) {
   test("Should contain all coordinates") {
@@ -12,5 +12,36 @@ class SquaredBoardSpec extends BoardSpec(new SquaredBoardFactory) {
 
     board.allCoordinates.foreach(c => assert(coordinates.contains(c)))
     coordinates.foreach(c => assert(board.allCoordinates.contains(c)))
+  }
+
+  test("Should show correctly") {
+    val size: Int = 9
+
+    def hasMine(coordinate: Coordinate): Boolean =
+      coordinate match {
+        case SquaredCoordinate(x, _, _) if x == 0 => true
+        case _                                    => false
+      }
+
+    val toUncover =
+      Seq.tabulate(3)(SquaredCoordinate(1, _, size))
+    val toFlag =
+      Seq.tabulate(3)(SquaredCoordinate(0, _, size))
+
+    val initialBoard: Board = new SquaredBoard(size, hasMine)
+
+    val uncovered =
+      toUncover.foldLeft(initialBoard)(_ uncover _)
+
+    val flagged =
+      toFlag.foldLeft(uncovered)(_ flag _)
+
+    val expected =
+      """F | F | F
+        |2 | 3 | 2
+        |+ | + | +
+        |""".stripMargin
+
+    assertNoDiff(flagged.show, expected)
   }
 }

--- a/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredCoordinateParserSpec.scala
+++ b/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredCoordinateParserSpec.scala
@@ -1,0 +1,40 @@
+package io.scalac.minesweeper.squared
+
+import io.scalac.minesweeper.api.Generators
+import munit.ScalaCheckSuite
+import org.scalacheck.Gen.*
+import org.scalacheck.Prop.*
+
+class SquaredCoordinateParserSpec extends ScalaCheckSuite {
+  val gen = new Generators(new SquaredBoardFactory)
+  import gen.*
+
+  property("Parse valid coordinate") {
+    forAll(boardGen) { board =>
+      val max = SquaredCoordinate.maxIndex(board.size)
+      forAll(choose(0, max), choose(0, max)) { (x, y) =>
+        val obtained =
+          SquaredCoordinateParser.parse(s"${x.toString} ${y.toString}", board)
+        assertEquals(obtained, Some(SquaredCoordinate(x, y, board.size)))
+      }
+    }
+  }
+
+  property("Return None for coordinates out of bounds") {
+    forAll(boardGen) { board =>
+      val outOfBoundsGen = posNum[Int].filter(_ >= board.size)
+      forAll(outOfBoundsGen, outOfBoundsGen) { (x, y) =>
+        val obtained =
+          SquaredCoordinateParser.parse(s"${x.toString} ${y.toString}", board)
+        assertEquals(obtained, None)
+      }
+    }
+  }
+
+  property("Return None for invalid coordinates") {
+    forAll(boardGen, alphaNumStr) { (board, str) =>
+      val obtained = SquaredCoordinateParser.parse(str, board)
+      assertEquals(obtained, None)
+    }
+  }
+}

--- a/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredCoordinateSpec.scala
+++ b/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredCoordinateSpec.scala
@@ -3,8 +3,8 @@ package io.scalac.minesweeper.squared
 import munit.FunSuite
 
 class SquaredCoordinateSpec extends FunSuite {
-  private val boardSize = 8
-  private val lastIndex = boardSize - 1
+  private val boardSize = 9
+  private val lastIndex = SquaredCoordinate.maxIndex(boardSize)
   private val extremes = Seq(0, lastIndex)
   private val middle = 1 until lastIndex
 


### PR DESCRIPTION
Adding a CLI to play the game requires some small additions to the API to be able to, for example, show the state of the board on every player's movement. It also uncovers the requirement to know the mined neighbors of a coordinate.
These changes keep the initial modularized approach. Please notice how `cli` module is defined independently from the squared implementation and then everything is joined in `cli-squared` module.